### PR TITLE
Switch to passing slices with isolate scope

### DIFF
--- a/src/js/sp-pie.js
+++ b/src/js/sp-pie.js
@@ -23,14 +23,15 @@ angular
             restrict: 'AE',
             type: 'svg',
             replace: 'true',
-            scope: true,
+            scope: {
+                slices: '&'
+            },
             template: tmpl,
             link: function(scope, elem, attr){
                 elem.attr('style', 'width:' + attr.size + 'px');
-                var slices = scope.$parent[attr.slices];
                 var total = 0;
 
-                angular.forEach(slices, function(v){
+                angular.forEach(scope.slices(), function(v){
                     var ci = angular
                         .element(document.createElementNS('http://www.w3.org/2000/svg', 'circle'))
                         .attr('r', '25%').attr('cx', '50%').attr('cy', '50%')


### PR DESCRIPTION
Thanks again for the great project :+1:!

At the moment, `slices` is fetched by looking for an attribute in the parent scope with the name equal to the directive's `slice` attribute. There are a few limitations with this: the main being that any 'dotted' scope variable will fail. For example when using the [`controllerAs` syntax](https://github.com/johnpapa/angular-styleguide#controlleras-view-syntax) or a nested object:

``` js
app.controller('DashboardController', function() {
  $scope.data = [{ "value": 30, "color": "#f06" }, { "value": 70, "color": "blue" }];
})

app.controller('AnotherController', function() {
  $scope.nested = { data: { "value": 30, "color": "#f06" }, { "value": 70, "color": "blue" } };
})
```

``` html
<div ng-controller='DashboardController as vm'>
  <sp-pie slices='vm.data'></sp-pie>
</div>

<div ng-controller='AnotherController'>
  <sp-pie slices='nested.data'></sp-pie>
</div>
```

We also can't pass a function:

``` js
app.controller('RandController', function() {
  $scope.randomData = function() {
    var randNum = Math.random() * 100;
    return [{ "value": randNum, "color": "#f06" }, { "value":  100 - randNum, "color": "blue" } }];
  }
})
```

``` html
<div ng-controller='RandController'>
  <sp-pie slices='randomData()'></sp-pie>
</div>
```

This PR addresses these limitations by switching to using an isolate scope, and passing `slices` in as a scope property rather than an attribute :relaxed:.
